### PR TITLE
Added logic to prevent multiple callbacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,7 @@ passport.use(new GoogleStrategy({
 
         await newUser.save();
         cb(null, newUser);
-      }
-      cb(null, doc);
+      } else cb(null, doc);
     })
 
   }));
@@ -102,8 +101,7 @@ passport.use(new TwitterStrategy({
 
         await newUser.save();
         cb(null, newUser);
-      }
-      cb(null, doc);
+      } else cb(null, doc);
     })
 
   }
@@ -134,8 +132,7 @@ passport.use(new GitHubStrategy({
 
         await newUser.save();
         cb(null, newUser);
-      }
-      cb(null, doc);
+      } else cb(null, doc);
     })
 
   }


### PR DESCRIPTION
Modified passport use strategies to add an else statement if the document exists and to only call a single callback.
Fixes #1 